### PR TITLE
Fix: Update userdata.sh to fix dependency issues & Add policy for ec2-instance-connect

### DIFF
--- a/cdk_bedrock_rag_chatbot/lib/userdata.sh
+++ b/cdk_bedrock_rag_chatbot/lib/userdata.sh
@@ -7,7 +7,7 @@ sudo apt-get update -y
 sudo apt-get install -y ec2-instance-connect
 sudo apt-get install -y git
 sudo apt-get install -y python3-pip
-sudo apt-get install -y python3.8-venv
+sudo apt-get install -y python3-venv
 
 # Clone repository
 cd /home/ubuntu
@@ -20,6 +20,7 @@ source /home/ubuntu/my_env/bin/activate
 
 # Install dependencies
 cd kr-tech-blog-sample-code/cdk_bedrock_rag_chatbot/application
+sudo apt install -y cargo
 pip3 install -r requirements.txt
 
 # Create systemd service


### PR DESCRIPTION
## Issue 1: Installing `python3.8-venv` occurs an error
```bash
$ sudo apt-get install -y python3.8-venv
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package python3.8-venv
E: Couldn't find any package by glob 'python3.8-venv'
E: Couldn't find any package by regex 'python3.8-venv'
```
--> Solved by installing `python3-venv` instead of `python3.8-venv`

## Issue 2: tokenizer is not installed
```bash
    ERROR: Command errored out with exit status 1:
     command: /home/ubuntu/my_env/bin/python3 /tmp/tmpemwv5ydg prepare_metadata_for_build_wheel /tmp/tmp_lflw1fe
         cwd: /tmp/pip-install-c49tvcy3/tokenizers
    Complete output (6 lines):
    
    Cargo, the Rust package manager, is not installed or is not on PATH.
    This package requires Rust and Cargo to compile extensions. Install it through
    the system's package manager or via https://rustup.rs/
    
    Checking for Rust toolchain....
```

--> Solved by updating userdata.sh to install tokenizer with cargo package
(Similar issue & solution: https://github.com/aws-samples/multi-modal-chatbot-with-advanced-rag/pull/13)


- - - 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
